### PR TITLE
Fixed bug mutating external record object

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,14 +36,14 @@ class BunyanStream extends EventEmitter {
         var opts = {
             level: levels[record.level]
             , app: record.name
-            , context: record
+            , context: Object.assign({}, record)
         };
 
         // remove duplicate fields
-        delete record.level;
-        delete record.timestamp;
-        delete record.name;
-        delete record.msg;
+        delete opts.context.level;
+        delete opts.context.timestamp;
+        delete opts.context.name;
+        delete opts.context.msg;
 
         try {
             this.logger.log(message, opts);


### PR DESCRIPTION
Fixes #2 by first creating a copy of the record object, then deleting fields from the local copy.

Example code:
```javascript
const bunyan = require('bunyan');

/* Basic stream which will get raw data and print it to the console */
class SimpleStream {
  write(record) {
    console.log(record);
  };
}

let LogDNAStream = require('logdna-bunyan').BunyanStream;
let logDNA = new LogDNAStream({
  key: '...apikey...'
});

var logger = bunyan.createLogger({
  name: 'test',
  streams: [
    { stream: new SimpleStream(), type: 'raw' }, // first: basic stream
    { stream: logDNA, type: 'raw' },             // second: logdna
    { stream: new SimpleStream(), type: 'raw' }, // third: basic stream
  ]
});

logger.warn('This is a warning');
```

Result before the fix:
```
{ name: 'test',
  hostname: 'hostname',
  pid: 3296,
  level: 40,
  msg: 'This is a warning',
  time: 2018-04-21T10:36:05.294Z,
  v: 0 }
{ hostname: 'hostname',
  pid: 3296,
  time: 2018-04-21T10:36:05.294Z,
  v: 0 }
```

Result after the fix:
```
{ name: 'test',
  hostname: 'hostname',
  pid: 3532,
  level: 40,
  msg: 'This is a warning',
  time: 2018-04-21T10:51:37.421Z,
  v: 0 }
{ name: 'test',
  hostname: 'hostname',
  pid: 3532,
  level: 40,
  msg: 'This is a warning',
  time: 2018-04-21T10:51:37.421Z,
  v: 0 }
```