### PR TITLE
Stop requiring `eslint` as a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   },
   "homepage": "https://github.com/logdna/logdna-bunyan#readme",
   "dependencies": {
-    "eslint": "^6.5.1",
     "logdna": "^3.5.0"
+  },
+  "devDependencies": {
+    "eslint": "^6.5.1"
   }
 }


### PR DESCRIPTION
It appears that `logdna-bunyan` does not use `eslint` at run time, only for linting at development time, so this PR removes that dependency.

This PR is motivated by a [prototype pollution vulnerability in `lodash`](https://github.com/lodash/lodash/issues/4738), which `eslint` has a dependency on, and which `lodash`'s maintainers [seem not to be acting on](https://github.com/lodash/lodash/pull/4759). By eliminating `eslint` as a production dependency, we eliminate the transitive dependency on `lodash`.